### PR TITLE
feat: User 대표 Tag 추출

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import threading
 from src.Consumer.KafkaConsumer import Consume
 from src.Consumer.QdrantClient import InitQdrant
 from src.Service.SearchUser import SearchUsers
+from src.Service.RepresentUser import RepresentTags
 
 app = FastAPI(title="Matching Service")
 
@@ -30,6 +31,19 @@ async def SearchUser(tags: str, topK: int = 5, topKperTag: int = 5):
         return {
             "status": 500,
             "message": "유저 검색 실패",
+            "error": str(e),
+        }
+
+
+# 유저의 대표 태그 검색 API
+async def SearchRepresent(userID: int, topK: int):
+    try:
+        tags = RepresentTags(userID, topK)
+        return {"status": 200, "meassage": "대표 태그 추출 성공", "data": tags}
+    except Exception as e:
+        return {
+            "status": 500,
+            "message": "대표 태그 추출 실패",
             "error": str(e),
         }
 

--- a/src/Service/RepresentUser.py
+++ b/src/Service/RepresentUser.py
@@ -1,0 +1,49 @@
+import os
+import numpy as np
+from dotenv import load_dotenv
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
+
+envPath = os.path.join(os.path.dirname(__file__), "..", "..", ".env")
+load_dotenv(dotenv_path=os.path.abspath(envPath))
+QDRANT_COLLECTION = os.getenv("QDRANT_COLLECTION")
+QDRANT_HOST = os.getenv("QDRANT_HOST")
+QDRANT_PORT = os.getenv("QDRANT_PORT")
+
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+# Cosine Similarity 계산하는 함수
+def cosineSim(vec1, vec2):
+    v1, v2 = np.array(vec1), np.array(vec2)
+    return float(np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2)))
+
+
+# 유저의 대표 태그를 topK 개 뽑는 함수
+def RepresentTags(userID: int, topK: int = 5):
+    # Qdrant에서 해당 유저의 모든 태그 벡터 가져오기
+    points, _ = client.scroll(
+        collection_name=QDRANT_COLLECTION,
+        scroll_filter=Filter(
+            must=[FieldCondition(key="userID", match=MatchValue(value=userID))]
+        ),
+        with_vectors=True,
+        with_payload=True,
+    )
+
+    if not points:
+        return []
+
+    tagVectors = [(point.payload["tag"], point.vector) for point in points]
+
+    # 대표 벡터 (유저) 생성
+    vectors = np.array([vec for _, vec in tagVectors])
+    RepresentVector = np.mean(vectors, axis=0)
+
+    # 각 태그 벡터와 대표 벡터 간 유사도 계산
+    similarities = [(tag, cosineSim(RepresentVector, vec)) for tag, vec in tagVectors]
+
+    # 유사도 기준 정렬 후 대표 태그 선택
+    RepresentTags = sorted(similarities, key=lambda x: x[1], reverse=True)[:topK]
+    return [tag for tag, _ in RepresentTags]


### PR DESCRIPTION
JIRA: GUC-148
resolves: #9

## 📌 Jira Issue

- 관련 티켓: [GUC-148](https://sh0314.atlassian.net/browse/GUC-148)
- 관련 GitHub 이슈: #9 

---

## ✨ PR Description

- 변경 사항 설명:
    - User의 대표 Tag를 K개 뽑습니다.
    - Cosine Distance를 이용합니다.

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-148]: https://sh0314.atlassian.net/browse/GUC-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ